### PR TITLE
Use correct document reference, fixes #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ exports.decorateTerm = (Term, { React }) => {
                 }
 
                 if (this.props.isTermActive) {
-                    const doc = this.el.term.document_;
+                    const doc = this.el.props.term.document_;
 
                     this.keys = new Mousetrap(doc);
 


### PR DESCRIPTION
Tested on Windows x64 on Hyper 1.3.3 and confirmed to work with both versions of keyboard shortcuts.

Should fix #9. Probably fixes #14 too.

Needs testing on other systems.